### PR TITLE
Add a Docker build argument for image size

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -68,9 +68,10 @@ RUN rm /mnt/root/usr/lib/systemd/system/userconfig.service \
  && rm /mnt/root/etc/systemd/system/multi-user.target.wants/userconfig.service
 
  # Create new distro image from modified boot and root
+ARG IMAGE_SIZE=2G
 ARG BUILD_DIR
 RUN mkdir $BUILD_DIR
-RUN guestfish -N $BUILD_DIR/distro.img=bootroot:vfat:ext4:2G \
+RUN guestfish -N $BUILD_DIR/distro.img=bootroot:vfat:ext4:$IMAGE_SIZE \
  && guestfish add $BUILD_DIR/distro.img : run : mount /dev/sda1 / : glob copy-in /mnt/boot/* / : umount / : mount /dev/sda2 / : glob copy-in /mnt/root/* / \
  && sfdisk --part-type $BUILD_DIR/distro.img 1 c
 
@@ -98,7 +99,7 @@ ARG KERNEL_BRANCH
 ARG BUILD_DIR
 
 # Clone the RPI kernel repo
-RUN git clone --single-branch --branch $KERNEL_BRANCH $KERNEL_GIT $BUILD_DIR/linux/
+RUN git clone --single-branch --depth=1 --branch $KERNEL_BRANCH $KERNEL_GIT $BUILD_DIR/linux/
 
 # Kernel compile options
 ARG ARCH=arm64


### PR DESCRIPTION
Image size can be specified as a Docker build argument instead of being fixed at `2G`. I have tested 2G up to 16G. Using a larger image size enables full versions of Raspberry Pi OS to be emulated. Fixes #20.

Also adds a tweak to speed up building by only cloning the most recent kernel branch commit. In the dockerfile [line 101](https://github.com/ptrsr/pi-ci/blob/a3108fc40f18a379bf5c7bec55052cc04a7fe197/dockerfile#L101) add the `--depth=1` switch.