### PR TITLE
Enable kernel module support

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -115,7 +115,8 @@ RUN make -C $BUILD_DIR/linux custom.config \
  && mv $BUILD_DIR/linux/arch/arm64/boot/Image $BUILD_DIR/kernel.img
 
 # Build kernel modules
-RUN mkdir -p $BUILD_DIR/k_mod && make -C $BUILD_DIR/linux -j$(nproc) INSTALL_MOD_PATH=$BUILD_DIR/k_mod modules_install
+RUN mkdir -p $BUILD_DIR/k_mod && make -C $BUILD_DIR/linux -j$(nproc) \
+ INSTALL_MOD_PATH=$BUILD_DIR/k_mod modules_install
 
 # ---------------------------
 FROM ubuntu:24.04 AS emulator

--- a/dockerfile
+++ b/dockerfile
@@ -115,8 +115,8 @@ RUN make -C $BUILD_DIR/linux custom.config \
  && mv $BUILD_DIR/linux/arch/arm64/boot/Image $BUILD_DIR/kernel.img
 
 # Build kernel modules
-RUN mkdir -p $BUILD_DIR/k_mod && make -C $BUILD_DIR/linux -j$(nproc) \
- INSTALL_MOD_PATH=$BUILD_DIR/k_mod modules_install
+RUN mkdir -p $BUILD_DIR/virt_kmods && make -C $BUILD_DIR/linux -j$(nproc) \
+ INSTALL_MOD_PATH=$BUILD_DIR/virt_kmods modules_install
 
 # ---------------------------
 FROM ubuntu:24.04 AS emulator
@@ -153,7 +153,7 @@ RUN mkdir $BASE_DIR
 
 COPY --from=image-builder $BUILD_DIR/$IMAGE_FILE_NAME $BASE_DIR/$IMAGE_FILE_NAME
 COPY --from=kernel-builder $BUILD_DIR/$KERNEL_FILE_NAME $BASE_DIR/$KERNEL_FILE_NAME
-COPY --from=kernel-builder $BUILD_DIR/k_mod $BASE_DIR
+COPY --from=kernel-builder $BUILD_DIR/virt_kmods $BASE_DIR
 
 # Helper script on running container
 ENTRYPOINT ["/app/run.py"]

--- a/src/app/func/init.py
+++ b/src/app/func/init.py
@@ -4,17 +4,18 @@ from lib.process import run
 
 
 def check_base_file(file_name, base_dir, dist_dir):
+  base_file = f'{base_dir}/{file_name}'
+  dist_file = f'{dist_dir}/{file_name}'
   file_exists = os.path.exists(f'{dist_dir}/{file_name}')
   if not file_exists:
     # Copy base file to shared volume
     log.info(f"No '{file_name}' provided in volume, providing default one ...")
-    if os.path.isfile(f'{base_dir}/{file_name}'):
-      shutil.copyfile(f'{base_dir}/{file_name}', f'{dist_dir}/{file_name}')
-    if os.path.isdir(f'{base_dir}/{file_name}'):
-      shutil.copytree(f'{base_dir}/{file_name}', f'{dist_dir}/{file_name}', symlinks=False, ignore_dangling_symlinks=True)
-  else:
-    log.info(f"'{file_name}' already exists ...")
-
+    if os.path.isfile(base_file):
+      shutil.copyfile(base_file, dist_file)
+    if os.path.isdir(base_file):
+      shutil.copytree(base_file, dist_file, symlinks=False, ignore_dangling_symlinks=True)
+    return False # file did not exist so it was copied from the default
+  return True # file does exist
 
 def start(opts):
   # Check if (Docker) volume folder exists
@@ -37,7 +38,8 @@ def start(opts):
     
     # Check and resolve required files for running emulator
     for file in base_files:
-      check_base_file(file, opts.BASE_DIR, opts.DIST_DIR)
+      if check_base_file(file, opts.BASE_DIR, opts.DIST_DIR):
+        log.info(f"'{file}' already exists ...")
 
 
 # init command parser

--- a/src/app/func/init.py
+++ b/src/app/func/init.py
@@ -4,11 +4,14 @@ from lib.process import run
 
 
 def check_base_file(file_name, base_dir, dist_dir):
-  has_file = os.path.isfile(f'{dist_dir}/{file_name}')
-  if not has_file:
+  file_exists = os.path.exists(f'{dist_dir}/{file_name}')
+  if not file_exists:
     # Copy base file to shared volume
     log.info(f"No '{file_name}' provided in volume, providing default one ...")
-    shutil.copyfile(f'{base_dir}/{file_name}', f'{dist_dir}/{file_name}')
+    if os.path.isfile(f'{base_dir}/{file_name}'):
+      shutil.copyfile(f'{base_dir}/{file_name}', f'{dist_dir}/{file_name}')
+    if os.path.isdir(f'{base_dir}/{file_name}'):
+      shutil.copytree(f'{base_dir}/{file_name}', f'{dist_dir}/{file_name}', symlinks=False, ignore_dangling_symlinks=True)
   else:
     log.info(f"'{file_name}' already exists ...")
 
@@ -28,7 +31,8 @@ def start(opts):
 
     base_files = [ 
       opts.IMAGE_FILE_NAME,
-      opts.KERNEL_FILE_NAME
+      opts.KERNEL_FILE_NAME,
+      'lib/modules/'
     ]
     
     # Check and resolve required files for running emulator

--- a/src/app/func/start.py
+++ b/src/app/func/start.py
@@ -45,7 +45,7 @@ def start(opts):
     -append \"rw console=ttyAMA0 root=/dev/vda2 rootfstype=ext4 rootdelay=1 loglevel=2\" \
     -drive file={image_path},format=qcow2,id=hd0,if=none,cache=writeback \
     -device virtio-blk,drive=hd0,bootindex=0 \
-    -virtfs local,path={modules_path},mount_tag=k_mod0,security_model=passthrough,id=k_mod0 \
+    -virtfs local,path={modules_path},mount_tag=pi-ci_virt_kmods,security_model=passthrough,id=pi-ci_virt_kmods \
     -netdev user,id=mynet,hostfwd=tcp::2222-:22 \
     -device virtio-net-pci,netdev=mynet \
     -nographic -no-reboot

--- a/src/app/func/start.py
+++ b/src/app/func/start.py
@@ -2,13 +2,7 @@ import os, shutil, subprocess
 from lib.logger import log
 from lib.process import run
 
-
-def check_base_file(file_name, base_dir, dist_dir):
-  has_file = os.path.isfile(f'{dist_dir}/{file_name}')
-  if not has_file:
-    # Copy base file to shared volume
-    log.info(f"No '{file_name}' provided in volume, providing default one ...")
-    shutil.copyfile(f'{base_dir}/{file_name}', f'{dist_dir}/{file_name}')
+from func.init import check_base_file
 
 
 def start(opts):
@@ -25,7 +19,8 @@ def start(opts):
 
     base_files = [ 
       opts.IMAGE_FILE_NAME,
-      opts.KERNEL_FILE_NAME
+      opts.KERNEL_FILE_NAME,
+      'lib/modules/'
     ]
     
     # Check and resolve required files for running emulator
@@ -36,6 +31,7 @@ def start(opts):
   run_dir = opts.DIST_DIR if has_volume else opts.BASE_DIR
   image_path = f'{run_dir}/{opts.IMAGE_FILE_NAME}'
   kernel_path = f'{run_dir}/{opts.KERNEL_FILE_NAME}'
+  modules_path = f'{run_dir}/lib/modules/'
 
   # Start emulator
   log.info("Starting the emulator ...")
@@ -49,7 +45,7 @@ def start(opts):
     -append \"rw console=ttyAMA0 root=/dev/vda2 rootfstype=ext4 rootdelay=1 loglevel=2\" \
     -drive file={image_path},format=qcow2,id=hd0,if=none,cache=writeback \
     -device virtio-blk,drive=hd0,bootindex=0 \
-    -virtfs local,path=/{opts.BASE_DIR}/lib/modules,mount_tag=k_mod0,security_model=passthrough,id=k_mod0 \
+    -virtfs local,path={modules_path},mount_tag=k_mod0,security_model=passthrough,id=k_mod0 \
     -netdev user,id=mynet,hostfwd=tcp::2222-:22 \
     -device virtio-net-pci,netdev=mynet \
     -nographic -no-reboot

--- a/src/app/func/start.py
+++ b/src/app/func/start.py
@@ -49,6 +49,7 @@ def start(opts):
     -append \"rw console=ttyAMA0 root=/dev/vda2 rootfstype=ext4 rootdelay=1 loglevel=2\" \
     -drive file={image_path},format=qcow2,id=hd0,if=none,cache=writeback \
     -device virtio-blk,drive=hd0,bootindex=0 \
+    -virtfs local,path=/{opts.BASE_DIR}/lib/modules,mount_tag=k_mod0,security_model=passthrough,id=k_mod0 \
     -netdev user,id=mynet,hostfwd=tcp::2222-:22 \
     -device virtio-net-pci,netdev=mynet \
     -nographic -no-reboot

--- a/src/conf/fstab
+++ b/src/conf/fstab
@@ -1,3 +1,4 @@
 proc            /proc           proc    defaults          0       0
 /dev/mmcblk0p1  /boot/firmware  vfat    defaults          0       2
+k_mod0		/lib/modules	9p	defualts	  0	  0
 /dev/mmcblk0p2  /               ext4    defaults,noatime  0       1

--- a/src/conf/fstab
+++ b/src/conf/fstab
@@ -1,4 +1,4 @@
 proc            /proc           proc    defaults          0       0
 /dev/mmcblk0p1  /boot/firmware  vfat    defaults          0       2
-k_mod0		/lib/modules	9p	defaults	  0	  0
+k_mod0          /lib/modules    9p      defaults,nofail   0       0
 /dev/mmcblk0p2  /               ext4    defaults,noatime  0       1

--- a/src/conf/fstab
+++ b/src/conf/fstab
@@ -1,4 +1,4 @@
 proc            /proc           proc    defaults          0       0
 /dev/mmcblk0p1  /boot/firmware  vfat    defaults          0       2
-k_mod0		/lib/modules	9p	defualts	  0	  0
+k_mod0		/lib/modules	9p	defaults	  0	  0
 /dev/mmcblk0p2  /               ext4    defaults,noatime  0       1

--- a/src/conf/fstab
+++ b/src/conf/fstab
@@ -1,4 +1,5 @@
-proc            /proc           proc    defaults          0       0
-/dev/mmcblk0p1  /boot/firmware  vfat    defaults          0       2
-k_mod0          /lib/modules    9p      defaults,nofail   0       0
-/dev/mmcblk0p2  /               ext4    defaults,noatime  0       1
+proc              /proc           proc    defaults          0       0
+/dev/mmcblk0p1    /boot/firmware  vfat    defaults          0       2
+# Kernel modules for running in pi-ci's virtual emulator
+pi-ci_virt_kmods  /lib/modules    9p      defaults,nofail   0       0
+/dev/mmcblk0p2    /               ext4    defaults,noatime  0       1


### PR DESCRIPTION
The Raspberry Pi OS and kernel support kernel modules out of the box. pi-ci builds a custom kernel to boot via qemu, but it does not build or install the accompanying kernel modules. This PR adds support for kernel modules in pi-ci.

`dockerfile` is modified to build the kernel modules in the same stage as the main kernel build. Modules are then "installed" to a directory in kernel-builder where it can be copied into the emulator image later. `start.py` uses virtfs to map the modules directory into qemu. `start.py` and `init.py` are modified to remove the redundancy of `check_base_file()` and to add support for copying the modules directory into a Docker volume.

From a running qemu instance, the loaded kernel modules can be checked by the `lsmod` command.

This PR may address some of the questions raised in #17.