### PR TITLE
Simplify specifying different Raspberry Pi OS and kernel versions

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -4,9 +4,11 @@ ARG KERNEL_BRANCH=rpi-6.6.y
 ARG KERNEL_GIT=https://github.com/raspberrypi/linux.git
 
 # Distro source
-ARG DISTRO_DATE=2024-11-19
-ARG DISTRO_FILE=$DISTRO_DATE-raspios-bookworm-arm64-lite.img
-ARG DISTRO_IMG=https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-$DISTRO_DATE/$DISTRO_FILE.xz
+ARG DISTRO_TYPE="lite_" # Options: "", "lite_", "full_", "oldstable_", "oldstable_lite_", "oldstable_full_"
+ARG DISTRO_DEBIAN_CODENAME="" # Options: "", "trixie", "bookworm", "bullseye", "buster"
+ARG DISTRO_DATE="2024-11-19" # Options: "", "YYYY*", "YYYY-MM*", "YYYY-MM-DD"
+# If the Debian base or relase date are unspecified, use the most recent
+# DISTRO_TYPE other than "lite_" requires a larger image, edit Line 80
 
 # Default directory and file names
 ARG BUILD_DIR=/build/
@@ -29,12 +31,20 @@ RUN apt-get update && apt install -y \
     linux-image-generic \
     xz-utils
 
-ARG DISTRO_FILE
-ARG DISTRO_IMG
-
-# Download raspbian distro
-RUN wget -nv -O /tmp/$DISTRO_FILE.xz $DISTRO_IMG \
- && unxz /tmp/$DISTRO_FILE.xz
+# Download raspbian distro that matches specified parameters
+ARG DISTRO_TYPE
+ARG DISTRO_DEBIAN_CODENAME
+ARG DISTRO_DATE
+ARG DISTRO_FILE="distro_download"
+RUN wget -q -O - https://downloads.raspberrypi.com/rss.xml \
+    | grep "images/raspios_${DISTRO_TYPE}arm64" \
+    | grep "${DISTRO_DEBIAN_CODENAME}-" \
+    | grep "${DISTRO_DATE}-" \
+    | sort \
+    | tail -n 1 \
+    | sed 's <link>\(.*\).torrent</link> \1 ' > /tmp/distro.url \
+    && wget -nv -O /tmp/$DISTRO_FILE.xz -i /tmp/distro.url \
+    && unxz /tmp/$DISTRO_FILE.xz
 
 # Extract distro boot and root
 RUN mkdir /mnt/root /mnt/boot \

--- a/dockerfile
+++ b/dockerfile
@@ -107,8 +107,8 @@ ARG KERNEL_GIT
 ARG KERNEL_BRANCH
 ARG BUILD_DIR
 
-# Clone the RPI kernel repo
-RUN git clone --single-branch --branch $KERNEL_BRANCH $KERNEL_GIT $BUILD_DIR/linux/
+# Clone the RPI kernel repo. If KERNEL_BRANCH is not set, the repo default will be used
+RUN git clone --depth=1 --single-branch ${KERNEL_BRANCH:+--branch $KERNEL_BRANCH} $KERNEL_GIT $BUILD_DIR/linux/
 
 # Kernel compile options
 ARG ARCH=arm64


### PR DESCRIPTION
The way Raspberry Pi OS names its image files makes it difficult to concatenate arguments to create a correct image file name. As a user, I would like to specify as little as possible to get the latest image while also having the ability to specify exactly which image if needed. Similarly for the kernel version, as I user I would like to use the default kernel version while also having the ability to specify the exact branch to build.

This PR changes the way the build arguments are handled so that when they are set to empty (`""`), the code will select the most recent or default value. This is straightforward for the kernel branch. If `KERNEL_BRANCH` is set, then Docker's [environment replacement functionality](https://docs.docker.com/reference/dockerfile#environment-replacement) will insert `--branch $KERNEL_BRANCH` into the `git clone` command.

Quick aside: I've included the `--depth=1` option here (also in #22), as it greatly speeds up clones of 6.12.y.

For the Raspberry Pi OS version, the [rss feed ](https://downloads.raspberrypi.com/rss.xml) lists all the images hosted on Raspberry Pi's servers along with links to the image. This list is filtered by three successive calls to `grep`, each with one of the build arguments. If the build argument is empty (`""`) grep is passed a dash (`-`), which will return all the previous results, as they all contain a dash. For the distro type (i.e. regular, lite, or full), the `DISTRO_TYPE` argument contains the string and a trailing underscore. The regular distro is specified by an empty `DISTRO_TYPE` argument.

The date of a release can be specified in full, or a subset down such as just the year. Date ranges cannot be specified.

After the `grep` filtering, the results are sorted, which will put the newest (of the matched images) at the bottom, and the bottom item is transformed into a URL by `sed`. This URL is saved to the file `/tmp/distro.url` and can be examined in the image-builder container.

I have tested this on kernels 6.6-y and 6.12.y; Bullseye, Bookworm, and Trixie; and regular, lite, full, and legacy lite options. For Trixie lite, the image size needs to be increased (see #22), and likewise for the regular and full images.

If this looks good, I propose changing the default values to
```
KERNEL_BRANCH=""
DISTRO_TYPE="lite_"
DISTRO_DEBIAN_CODENAME="bookworm"
DISTRO_DATE=""
```